### PR TITLE
Fix select bg in firefox & rename adsr

### DIFF
--- a/frontend/src/components/Dropdown.svelte
+++ b/frontend/src/components/Dropdown.svelte
@@ -1,5 +1,6 @@
 <style>
   select {
+    background: var(--module-background);
     color: var(--module-foreground);
     font-family: monospace;
     width: 100%;

--- a/frontend/src/modules/Envelope.svelte
+++ b/frontend/src/modules/Envelope.svelte
@@ -34,7 +34,7 @@
   })
 </script>
 
-<Panel name="adsr" height={9} width={8} custom_style={into_style(theme)}>
+<Panel name="envelope" height={9} width={8} custom_style={into_style(theme)}>
   {#await loading}
     <p>Loading...</p>
   {:then}


### PR DESCRIPTION
### What

Before:
<img width="143" alt="Screenshot 2022-05-07 at 13 11 11" src="https://user-images.githubusercontent.com/492261/167252472-a7fe8ce0-f8f2-4855-be85-f5191a921de7.png">

After:
<img width="144" alt="Screenshot 2022-05-07 at 13 32 26" src="https://user-images.githubusercontent.com/492261/167252481-234d55c9-7a24-46af-8ae9-05f2dcc82f25.png">

Also, renaming ADSR to Envelope - to not get confused when searching for adsr in the module search box.